### PR TITLE
add CentOS 7 and CVMFS support

### DIFF
--- a/portal/connect.py
+++ b/portal/connect.py
@@ -220,3 +220,10 @@ def delete_group(group_name):
             return True
         logger.error('Unable to remove group %s' %group_name)
     return False
+
+
+def get_group_gid(group_name):
+    resp = requests.get(base_url + "/v1alpha/groups/" + group_name, params=params)
+    if resp.status_code != requests.codes.ok:
+        raise Exception("Error getting group %s" % group_name)
+    subgroups = resp.json()["metadata"]["unix_id"]

--- a/portal/jupyterlab.py
+++ b/portal/jupyterlab.py
@@ -48,13 +48,13 @@ def start_notebook_maintenance():
     logger.info('Started notebook maintenance')
 
 # The main interface of the module
-def deploy_notebook(notebook_id, notebook_name, image, owner, globus_id, 
+def deploy_notebook(notebook_id, notebook_name, image, owner, owner_uid, connect_group, connect_gid, globus_id, cvmfs,
                     cpu_request, memory_request, gpu_request, cpu_limit, memory_limit, gpu_limit, 
                     gpu_memory, hours_remaining):
     validate(notebook_name, image, cpu_request, memory_request, gpu_request, cpu_limit, memory_limit, gpu_limit, gpu_memory)
     token_bytes = os.urandom(32)
     token = b64encode(token_bytes).decode()
-    create_pod(notebook_id, notebook_name, image, owner, globus_id, 
+    create_pod(notebook_id, notebook_name, image, owner, owner_uid, connect_group, connect_gid, globus_id, cvmfs,
                 cpu_request, memory_request, gpu_request, cpu_limit, memory_limit, gpu_limit, gpu_memory, 
                 hours_remaining, token)
     create_service(notebook_id, image)

--- a/portal/templates/jupyterlab/pod.yaml
+++ b/portal/templates/jupyterlab/pod.yaml
@@ -32,8 +32,12 @@ spec:
           key: token
     - name: OWNER
       value: {{owner}}
+    - name: OWNER_UID
+      value: "{{owner_uid}}"
     - name: CONNECT_GROUP
-      value: atlas-af
+      value: {{connect_group}}
+    - name: CONNECT_GID
+      value: "{{connect_gid}}"
     image: {{image}}
     imagePullPolicy: Always
     ports:
@@ -53,8 +57,18 @@ spec:
       - name: ceph-data
         mountPath: /data
         subPath: data
+      {% if cvmfs %}
+      - name: cvmfs
+        mountPath: /cvmfs
+        mountPropagation: HostToContainer
+      {% endif %}
   restartPolicy: Always
   volumes:
+    {% if cvmfs %}
+    - name: cvmfs
+      hostPath:
+        path: /cvmfs
+    {% endif %}
     - name: nfs-home
       nfs: 
         server: nfs.af.uchicago.edu

--- a/portal/templates/jupyterlab_form.html
+++ b/portal/templates/jupyterlab_form.html
@@ -108,7 +108,16 @@
                                 <option value="hub.opensciencegrid.org/usatlas/ml-platform:conda">ml-platform:conda</option>
                                 <option value="hub.opensciencegrid.org/usatlas/ml-platform:julia">ml-platform:julia</option>
                                 <option value="hub.opensciencegrid.org/usatlas/ml-platform:lava">ml-platform:lava</option>
+                                <option value="hub.opensciencegrid.org/usatlas/ml-platform:lava">ml-platform:centos7-experimental</option>
                             </select>
+                        </div>
+                    </div>
+                    <div class="row mb-2">
+                        <div class="col-sm-4">
+                            <label for="cvmfs" class="form-label my-2">Include ATLAS CVMFS</label>
+                        </div>
+                        <div class="col-sm-8">
+                            <input type="checkbox" name="cvmfs" class="form-control col" required/>
                         </div>
                     </div>
                     <button class="btn btn-sm btn-primary" type="submit" :disabled="!valid" onclick="loader(true)">Create notebook</button>

--- a/portal/views.py
+++ b/portal/views.py
@@ -56,6 +56,7 @@ def login():
             user = connect.find_user(session['globus_id'])
             if user:
                 session['unix_name'] = user['unix_name']
+                session['unix_id'] = user['unix_id']
                 profile = connect.get_user_profile(session['unix_name'])
                 session['role'] = profile['role'] if profile else 'nonmember'
             return redirect(url_for('home'))
@@ -224,6 +225,9 @@ def deploy_notebook():
         notebook['notebook_id'] = notebook['notebook_name'].lower()
         notebook['image'] = request.form['image']
         notebook['owner'] = session['unix_name']
+        notebook['owner_uid'] = session['unix_id']
+        notebook['connect_group'] = "atlas-af"
+        notebook['connect_gid'] = connect.get_group_gid("atlas-af")
         notebook['globus_id'] = session['globus_id']
         notebook['cpu_request'] = int(request.form['cpu'])
         notebook['memory_request'] = int(request.form['memory'])


### PR DESCRIPTION
This is a draft PR for adding a CentOS 7 and CVMFS support.

In the CentOS 7 image, I remove the provisioner and replace it with a simple `useradd` command that needs the username, user ID and group name+id.

I've added appropriate parameters to the notebook creation method for this, and added a new method for the connect library to get a group's ID. For now the group name is hard-coded in the caller in `views.py`.

I've also added support for CVMFS in the template and added it as appropriate to the calling functions. I also took a stab at adding a checkbox in the form for including CVMFS. 