### PR TITLE
Login node pref

### DIFF
--- a/portal/templates/jupyterlab/pod.yaml
+++ b/portal/templates/jupyterlab/pod.yaml
@@ -11,12 +11,32 @@ metadata:
   name: {{notebook_id}}
   namespace: {{namespace}}
 spec:
+  {% if gpu_request %}
   nodeSelector:
-    {% if gpu_request %}
     nvidia.com/gpu.memory: "{{gpu_memory}}"
-    {% else %}
-    hyperconverged: "true"
-    {% endif %}
+  {% else %}
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: partition
+            operator: NotIn
+            values:
+            - gpu
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 10
+        preference:
+          matchExpressions:
+          - key: partition
+            operator: In
+            values:
+            - login
+  tolerations:
+    - key: hub.jupyter.org/dedicated
+      operator: "Exists"
+      effect: "NoSchedule"
+  {% endif %}
   containers:
   - name: {{notebook_id}}
     args:


### PR DESCRIPTION
This PR changes the node selection logic from a simple selector on GPU memory to a more complex selector that does the following:

1. If GPU memory is specified, use the nodeSelector to pick an appropriate GPU node
2. If GPU memory is **not** specified, then assume it is a non-GPU pod. 
3. Allow scheduling onto "Jupyter-only" nodes. When scheduling, preferentially select login nodes (login04-08), which have dedicated resources for Jupyter pods, with a weight factor of 10 compared to any othet node. If all login nodes are full, the scheduler may **optionally** schedule onto any other node **except** GPU nodes.