### PR TITLE
Refactor JupyterLab deployment and add support for oct_upgrade image

### DIFF
--- a/portal/templates/jupyterlab/pod.yaml
+++ b/portal/templates/jupyterlab/pod.yaml
@@ -41,7 +41,7 @@ spec:
   - name: {{notebook_id}}
     args:
     - /.run
-    - /ML_platform_tests/SetupPrivateJupyterLab.sh
+    - {{start_script}}
     env:
     - name: "JUPYTER_TOKEN"
       value: {{token}}

--- a/portal/templates/jupyterlab_form.html
+++ b/portal/templates/jupyterlab_form.html
@@ -122,6 +122,9 @@
                                 <option value="hub.opensciencegrid.org/usatlas/analysis-dask-uc:main">AB-stable
                                 </option>
                                 <option value="hub.opensciencegrid.org/usatlas/analysis-dask-uc:dev">AB-dev</option>
+                                <option value="hub.opensciencegrid.org/usatlas/ml-platform:oct_upgrade">
+                                    ml-platform:oct_upgrade
+                                </option>
                             </select>
                         </div>
                     </div>


### PR DESCRIPTION
This commit refactors the `deploy_notebook` function in `jupyterlab.py` to include support for the `oct_upgrade` image. It adds a new condition to set the `start_script` variable to `/ML_platform_tests/SetupJupyterLab.sh` when the `image` contains `oct_upgrade`. Additionally, the `supported_images` function in the same file is updated to include the `oct_upgrade` image.

In the `pod.yaml` file, the `SetupPrivateJupyterLab.sh` script is replaced with the `start_script` variable, allowing for dynamic script selection based on the image.

Lastly, the `jupyterlab_form.html` template is modified to include the `ml-platform:oct_upgrade` option in the image dropdown menu.

These changes enhance the flexibility of JupyterLab deployment and provide support for the `oct_upgrade` image.