### PR TITLE
fix: update H200 MIG instance to 1g.18gb

### DIFF
--- a/portal/templates/jupyterlab_form.html
+++ b/portal/templates/jupyterlab_form.html
@@ -137,7 +137,7 @@ block assets %}
                 <option value="NVIDIA-A100-SXM4-40GB">
                   NVIDIA A100 (Whole)
                 </option>
-                <option value="NVIDIA-H200-NVL-MIG-1g.16gb">
+                <option value="NVIDIA-H200-NVL-MIG-1g.18gb">
                   NVIDIA H200 (MIG instance)
                 </option>
                 <option value="NVIDIA-GeForce-RTX-2080-Ti">


### PR DESCRIPTION
Updates the H200 MIG GPU product option in the JupyterLab configuration form from \`NVIDIA-H200-NVL-MIG-1g.16gb\` to \`NVIDIA-H200-NVL-MIG-1g.18gb\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)