### PR TITLE
ci: harden GitHub Actions security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,15 +5,26 @@ on:
     branches:
       - "main"
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  docker:
+  build:
+    name: Build and push image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # actions/checkout needs to read repository contents
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Docker Build & Push Action
-        uses: mr-smithers-excellent/docker-build-push@v6.4
+        uses: mr-smithers-excellent/docker-build-push@ef432483bd0252dd948d1d11e60c96a1c93646a9 # v7.0
         with:
           image: maniaclab/af-portal
           tags: latest, ${{ github.sha }}
@@ -21,8 +32,13 @@ jobs:
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_PASSWORD }}
 
+  deploy:
+    name: Trigger GitOps deployment
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v3.0.0
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.AAAS_GITOPS_DEPLOY_TRIGGER  }}
           repository: maniaclab/flux_apps

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,19 @@
 ci:
   autoupdate_commit_msg: "chore: update pre-commit hooks"
   autofix_commit_msg: "style: pre-commit fixes"
+  autoupdate_schedule: monthly
 
 exclude: ^.cruft.json|.copier-answers.yml|docs/css/fonts/.*|portal/templates/jupyterlab/.*\.yaml$
 
 repos:
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: "1.20.0"
+    rev: "fda77690955e9b63c6687d8806bafd56a526e45f" # frozen: 1.20.0
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==24.*]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v6.0.0"
+    rev: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c" # frozen: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -34,35 +35,35 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: "v1.10.0"
+    rev: "3a6eb0fadf60b3cccfd80bad9dbb6fae7e47b316" # frozen: v1.10.0
     hooks:
       - id: rst-backticks
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: "v3.8.3"
+    rev: "515f543f5718ebfd6ce22e16708bb32c68ff96e1" # frozen: v3.8.3
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
         args: [--prose-wrap=always]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.12"
+    rev: "6fec9b7edb08fd9989088709d864a7826dc74e80" # frozen: v0.15.12
     hooks:
       - id: ruff-check
         args: ["--fix", "--show-fixes"]
       - id: ruff-format
 
   - repo: https://github.com/codespell-project/codespell
-    rev: "v2.4.2"
+    rev: "57b21406f092110c18776e39b0bda50d37c945c8" # frozen: v2.4.3
     hooks:
       - id: codespell
         exclude: ".+.ipynb"
         args: ["-w", "-L", "SLAC,checkin,slac"]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: "v0.11.0.1"
+    rev: "745eface02aef23e168a8afb6b5737818efbea95" # frozen: v0.11.0.1
     hooks:
       - id: shellcheck
 
@@ -75,8 +76,15 @@ repos:
         exclude: .pre-commit-config.yaml
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: "0.37.2"
+    rev: "6b63472e72e1a91ed8a2f6d483790dfb644fa1d3" # frozen: 0.37.4
     hooks:
       - id: check-dependabot
       - id: check-github-workflows
       - id: check-readthedocs
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: 451b56af716f9f0d0c2b816503a3fd0cf8b036fa # frozen: v1.29.0
+    hooks:
+      - id: zizmor
+        files: "^\\.github"
+        args: [--persona=pedantic]

--- a/pixi.toml
+++ b/pixi.toml
@@ -4,6 +4,7 @@ channels = ["conda-forge"]
 name = "af-portal"
 platforms = ["osx-arm64"]
 version = "0.1.0"
+exclude-newer = "7d"
 
 [tasks]
 


### PR DESCRIPTION
## Summary

- Pin `actions/checkout`, `mr-smithers-excellent/docker-build-push`, and `peter-evans/repository-dispatch` to full commit SHAs (with version comments) instead of mutable tags.
- Split the single `docker` job in `main.yaml` into a `build` job (image build/push, uses HARBOR credentials) and a `deploy` job (GitOps repository-dispatch trigger, uses a separate token), so the two secrets are never live in the same job.
- Set `permissions: {}` at the workflow level and scope `contents: read` only to the `build` job that needs it for checkout.
- Set `persist-credentials: false` on the checkout step, and add a `concurrency` group to the workflow.
- Pin all `.pre-commit-config.yaml` hook revs to commit SHAs (`prek auto-update --freeze --cooldown-days 7`), add `autoupdate_schedule: monthly`, and add the `zizmor` pre-commit hook (scoped to `.github`, `--persona=pedantic`).
- Add `.github/dependabot.yml`: monthly grouped updates for the `github-actions` ecosystem with a 7-day cooldown (no config existed before).
- Add `exclude-newer = "7d"` to the `[workspace]` table in `pixi.toml` for a matching install cooldown.

## Major version changes

- `actions/checkout` v4.2.2 -> v7.0.1
- `mr-smithers-excellent/docker-build-push` v6.4 -> v7.0
- `peter-evans/repository-dispatch` v3.0.0 -> v4.0.1

These are the only functional-behavior risk in this PR. The `with:` inputs used here (image/tags/registry/credentials, token/repository/event-type/client-payload) are unchanged across the major versions per each project's release notes, but please confirm the first run.

## Held back

- `astral-sh/ruff-pre-commit` held at v0.15.12 (still SHA-pinned). Bumping to v0.16.1 triggered ruff-check/ruff-format changes across `portal/*.py`, `setup.py`, and `tests/test_downtime.py` (import sorting, `datetime`/`except Exception`/percent-format style findings, etc). Out of scope for a CI-security-only change; needs its own PR.
- `rbubley/mirrors-prettier` held at v3.8.3 (still SHA-pinned). Bumping to v3.9.6 reformatted `portal/templates/edit_profile.html` and `portal/templates/notebooks_admin.html`. Same reasoning as above.

## zizmor ignores

None added. `uvx zizmor --persona=pedantic .github` is clean after the workflow changes (permissions, persist-credentials, concurrency, and job split resolved every finding).

## Verification

- `uvx zizmor --persona=pedantic .github` -> no findings
- `uvx prek -a` -> all hooks pass
- No workflow `uses:` ref is a tag or branch; all are SHAs with version comments
