### PR TITLE
feat: split JupyterLab image dropdown into CPU and GPU variants

### DIFF
--- a/portal/jupyterlab.py
+++ b/portal/jupyterlab.py
@@ -405,11 +405,26 @@ def generate_notebook_name(owner):
     return None
 
 
-def supported_images():
-    """Returns a tuple of Docker images that are supported by the JupyterLab service."""
+def supported_cpu_images():
+    """Returns a tuple of Docker images that are supported by the JupyterLab service for CPU-only notebooks."""
     return (
-        "hub.opensciencegrid.org/usatlas/ml-platform:latest",
+        "hub.opensciencegrid.org/usatlas/ml-platform-cpu:latest",
         "hub.opensciencegrid.org/usatlas/ml-platform:2026.3",
+    )
+
+
+def supported_gpu_images():
+    """Returns a tuple of Docker images that are supported by the JupyterLab service for GPU notebooks."""
+    return (
+        "hub.opensciencegrid.org/usatlas/ml-platform-gpu:latest",
+        "hub.opensciencegrid.org/usatlas/ml-platform:2026.3",
+    )
+
+
+def supported_images():
+    """Returns a tuple of all Docker images supported by the JupyterLab service, CPU and GPU combined."""
+    # analysis-dask-uc images are valid for backend deployment but currently hidden from the form's dropdowns
+    return tuple(dict.fromkeys(supported_cpu_images() + supported_gpu_images())) + (
         "hub.opensciencegrid.org/usatlas/analysis-dask-uc:main",
         "hub.opensciencegrid.org/usatlas/analysis-dask-uc:dev",
     )

--- a/portal/templates/jupyterlab_form.html
+++ b/portal/templates/jupyterlab_form.html
@@ -189,7 +189,10 @@ block assets %}
               </select>
               <select v-else name="image" class="form-control">
                 {% for image in gpu_images %}
-                <option value="{{ image }}">{{ image.split('/')[-1] }}</option>
+                <option value="{{ image }}">
+                  {{ image.split('/')[-1] }}{% if '-gpu:' in image %} (GPU
+                  required){% endif %}
+                </option>
                 {% endfor %}
               </select>
             </div>

--- a/portal/templates/jupyterlab_form.html
+++ b/portal/templates/jupyterlab_form.html
@@ -182,29 +182,15 @@ block assets %}
               </label>
             </div>
             <div class="col-sm-8">
-              <select name="image" class="form-control">
-                <option
-                  value="hub.opensciencegrid.org/usatlas/ml-platform:latest"
-                >
-                  ml-platform:latest
-                </option>
-                <option
-                  value="hub.opensciencegrid.org/usatlas/ml-platform:2026.3"
-                >
-                  ml-platform:2026.3
-                </option>
-                <!--
-                <option
-                  value="hub.opensciencegrid.org/usatlas/analysis-dask-uc:main"
-                >
-                  AB-stable
-                </option>
-                <option
-                  value="hub.opensciencegrid.org/usatlas/analysis-dask-uc:dev"
-                >
-                  AB-dev
-                </option>
-		-->
+              <select v-if="instances == 0" name="image" class="form-control">
+                {% for image in cpu_images %}
+                <option value="{{ image }}">{{ image.split('/')[-1] }}</option>
+                {% endfor %}
+              </select>
+              <select v-else name="image" class="form-control">
+                {% for image in gpu_images %}
+                <option value="{{ image }}">{{ image.split('/')[-1] }}</option>
+                {% endfor %}
               </select>
             </div>
           </div>

--- a/portal/views.py
+++ b/portal/views.py
@@ -310,14 +310,14 @@ def configure_notebook():
     username = session["unix_name"]
     notebook_name = jupyterlab.generate_notebook_name(username)
     groups = connect.get_user_roles(username)
-    if "root.atlas-af.bigmem" in groups:
-        return render_template(
-            "jupyterlab_form.html", max_mem=256, notebook_name=notebook_name
-        )
-    else:
-        return render_template(
-            "jupyterlab_form.html", max_mem=32, notebook_name=notebook_name
-        )
+    max_mem = 256 if "root.atlas-af.bigmem" in groups else 32
+    return render_template(
+        "jupyterlab_form.html",
+        max_mem=max_mem,
+        notebook_name=notebook_name,
+        cpu_images=jupyterlab.supported_cpu_images(),
+        gpu_images=jupyterlab.supported_gpu_images(),
+    )
 
 
 @app.route("/jupyterlab/deploy", methods=["POST"])


### PR DESCRIPTION
Separates supported_images into supported_cpu_images and supported_gpu_images in jupyterlab.py, and swaps the form image select between the two based on the existing GPU instances count.

Assisted-by: Claude (Anthropic)