### PR TITLE
fix: reuse a single Kubernetes ApiClient in portal.jupyterlab

### DIFF
--- a/portal/jupyterlab.py
+++ b/portal/jupyterlab.py
@@ -123,11 +123,17 @@ else:
     config.load_kube_config()
     logger.info("Loaded default kubeconfig file")
 
+# Shared across every CoreV1Api/NetworkingV1Api call in this module. Each
+# ApiClient() owns its own urllib3 connection pool, so constructing a fresh
+# one per request (as this module previously did) leaks sockets/memory under
+# the frequent polling from /jupyterlab/get_notebooks.
+api_client = client.ApiClient()
+
 
 def start_notebook_maintenance():
     def inner():
         while True:
-            api = client.CoreV1Api()
+            api = client.CoreV1Api(api_client)
             pods = api.list_namespaced_pod(
                 namespace, label_selector="k8s-app=jupyterlab"
             ).items
@@ -170,7 +176,7 @@ def deploy_notebook(**settings):
     settings["start_script"] = "/usr/local/bin/SetupPrivateJupyterLab.sh"
     settings["notebook_id"] = sanitize_k8s_pod_name(settings["notebook_id"])
     templates = Environment(loader=FileSystemLoader("portal/templates/jupyterlab"))
-    api = client.CoreV1Api()
+    api = client.CoreV1Api(api_client)
     # Create a pod for the notebook (the notebook runs as a container inside the pod)
     template = templates.get_template("pod.yaml")
     pod = yaml.safe_load(template.render(**settings))
@@ -206,7 +212,7 @@ def deploy_notebook(**settings):
         else:
             raise
     # Create an ingress for the service (gives the notebook its own domain name and public key certificate)
-    api = client.NetworkingV1Api()
+    api = client.NetworkingV1Api(api_client)
     template = templates.get_template("ingress.yaml")
     ingress = yaml.safe_load(template.render(**settings))
     # api.create_namespaced_ingress(namespace=namespace, body=ingress)
@@ -236,7 +242,7 @@ def get_notebook(name=None, pod=None, **options):
     log: (boolean) When log is True, the pod log is included in the dict that gets returned
     url: (boolean) When url is True, the notebook URL is included in the dict that gets returned
     """
-    api = client.CoreV1Api()
+    api = client.CoreV1Api(api_client)
     if pod is None:
         pod = api.read_namespaced_pod(name=name.lower(), namespace=namespace)
     notebook = {}
@@ -340,7 +346,7 @@ def get_notebooks(owner=None, **options):
     url: (boolean) When url is True, the notebook URL is included in the dict that gets returned
     """
     notebooks = []
-    api = client.CoreV1Api()
+    api = client.CoreV1Api(api_client)
     pods = api.list_namespaced_pod(
         namespace,
         label_selector=(
@@ -363,7 +369,7 @@ def get_notebooks(owner=None, **options):
 
 def list_notebooks():
     """Returns a list of the names of all notebooks in the namespace."""
-    api = client.CoreV1Api()
+    api = client.CoreV1Api(api_client)
     pods = api.list_namespaced_pod(
         namespace=namespace, label_selector="k8s-app=jupyterlab"
     ).items
@@ -374,11 +380,11 @@ def remove_notebook(name):
     """Removes a notebook from the namespace, and all Kubernetes objects associated with the notebook."""
     try:
         id = name.lower()
-        api = client.CoreV1Api()
+        api = client.CoreV1Api(api_client)
         api.delete_namespaced_pod(id, namespace)
         api.delete_namespaced_service(id, namespace)
         api.delete_namespaced_secret(id, namespace)
-        api = client.NetworkingV1Api()
+        api = client.NetworkingV1Api(api_client)
         api.delete_namespaced_ingress(id, namespace)
         logger.info(f"Removed notebook {id} from namespace {namespace}")
         return True
@@ -389,7 +395,7 @@ def remove_notebook(name):
 
 def notebook_name_available(name):
     """Returns a boolean indicating whether a notebook name is available for use."""
-    api = client.CoreV1Api()
+    api = client.CoreV1Api(api_client)
     pods = api.list_namespaced_pod(
         namespace, field_selector=f"metadata.name={name.lower()}"
     )
@@ -447,7 +453,7 @@ def get_gpu_availability(product=None, memory=None):
        Return the sorted list of dicts.
     """
     gpus = {}
-    api = client.CoreV1Api()
+    api = client.CoreV1Api(api_client)
     if product:
         nodes = api.list_node(
             label_selector=f"gpu=true,nvidia.com/gpu.product={product}"
@@ -516,7 +522,7 @@ def get_expiration_date(pod):
 def get_pod(name):
     """Looks up a Kubernetes pod by its name and returns a pod object."""
     try:
-        api = client.CoreV1Api()
+        api = client.CoreV1Api(api_client)
         return api.read_namespaced_pod(name=name, namespace=namespace)
     except Exception:  # noqa: BLE001 -- deliberately broad: any lookup failure (including not-found) means "no such pod" to callers
         return None

--- a/tests/test_jupyterlab.py
+++ b/tests/test_jupyterlab.py
@@ -1,0 +1,56 @@
+"""Unit tests for portal.jupyterlab's Kubernetes client lifecycle."""
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+PORTAL_DIR = Path(__file__).parent.parent / "portal"
+
+
+def _install_fake_portal_app():
+    """Stub portal/portal.app so portal.jupyterlab can be imported without a
+    real portal.conf or Flask app (mirrors the bypass conftest.py uses for
+    portal.downtime, but jupyterlab imports portal.app directly)."""
+    fake_portal = types.ModuleType("portal")
+    fake_portal.__path__ = [str(PORTAL_DIR)]
+    sys.modules.setdefault("portal", fake_portal)
+
+    fake_app_module = types.ModuleType("portal.app")
+    fake_app = MagicMock()
+    fake_app.config = {"NAMESPACE": "af-jupyter"}
+    fake_app_module.app = fake_app
+    fake_app_module.logger = MagicMock()
+    sys.modules["portal.app"] = fake_app_module
+
+
+@pytest.fixture(scope="module")
+def jupyterlab():
+    _install_fake_portal_app()
+    with patch("kubernetes.config.load_kube_config"):
+        import portal.jupyterlab as jupyterlab_module
+    return jupyterlab_module
+
+
+class TestSharedApiClient:
+    def test_corev1api_calls_reuse_the_same_api_client(self, jupyterlab, monkeypatch):
+        """Every client.CoreV1Api() call site should share one ApiClient
+        instead of constructing (and leaking) a new one per call."""
+        seen_api_clients = []
+
+        def fake_corev1api(api_client=None):
+            seen_api_clients.append(api_client)
+            mock_api = MagicMock()
+            mock_api.list_namespaced_pod.return_value.items = []
+            return mock_api
+
+        monkeypatch.setattr(jupyterlab.client, "CoreV1Api", fake_corev1api)
+
+        jupyterlab.list_notebooks()
+        jupyterlab.notebook_name_available("some-notebook")
+
+        assert len(seen_api_clients) == 2
+        assert seen_api_clients[0] is not None
+        assert seen_api_clients[0] is seen_api_clients[1]


### PR DESCRIPTION
## Summary
- `portal/jupyterlab.py` called `client.CoreV1Api()` / `client.NetworkingV1Api()` fresh on every use (11 call sites), each spinning up its own `ApiClient` + urllib3 connection pool that was never closed.
- `/jupyterlab/get_notebooks` is polled every 10s per open browser tab (`portal/templates/jupyterlab.html:154`) and internally instantiates one of these per notebook owned by the user, so the single gunicorn worker (`boot.sh: --workers=1`) leaked memory continuously.
- Confirmed against the live cluster via flux-operator-mcp: Deployment `af` (namespace `af`) runs `replicas: 1` with an 8Gi memory limit; pod `af-58df4d8869-z484j` had `restartCount: 14` with `lastState.terminated.reason: OOMKilled` (exitCode 137), cycling roughly every 75-80 minutes. Because it's a single replica with no readiness probe, each OOM cycle drops the Service to zero backends, which is why af.uchicago.edu hangs and the gateway times out.
- Fix: construct one `client.ApiClient()` at module load and pass it into every `CoreV1Api`/`NetworkingV1Api` call, so the connection pool is shared instead of leaked per request.

## Test plan
- [x] Added `tests/test_jupyterlab.py`, which fails against the old code (each call site got a distinct/None api_client) and passes now that they share one `ApiClient`.
- [x] `pixi run pytest tests/` -- 9 passed
- [x] `pixi run -e dev pre-commit run --files portal/jupyterlab.py tests/test_jupyterlab.py` -- all hooks passed

## Related (tracked separately, in the flux_apps infra repo, not this one)
- Add a readiness/liveness probe to the `af` Deployment so nginx stops routing to a pod before gunicorn is actually listening.
- Bump the `af` Deployment to 2 replicas so a single pod's restart doesn't drop the site to zero backends.

Assisted-by: Claude (Anthropic)
